### PR TITLE
Clean up the Dockerfile to reduce the image size and improve caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM ubuntu:18.04
-RUN apt update
-RUN apt install gnupg apt-utils -y
-RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/clang.list
-RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main" > /etc/apt/sources.list.d/clang6.list
-RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" > /etc/apt/sources.list.d/clang7.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
-RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu xenial main" > /etc/apt/sources.list.d/gcc.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F
-RUN apt update
-RUN apt upgrade -y
-RUN apt install wget -y
-RUN wget https://raw.githubusercontent.com/wireshark/wireshark/master/tools/debian-setup.sh
-RUN chmod +x debian-setup.sh
-RUN ./debian-setup.sh --install-optional --install-deb-deps --install-test-deps gcc-5 g++-5 gcc-6 g++-6 gcc-7 g++-7 gcc-8 g++-8 clang-5.0 clang-6.0 clang-7
+
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" > /etc/apt/sources.list.d/clang.list \
+    && echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main" > /etc/apt/sources.list.d/clang6.list \
+    && echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" > /etc/apt/sources.list.d/clang7.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 \
+    && echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" > /etc/apt/sources.list.d/gcc.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
+
+ADD https://raw.githubusercontent.com/wireshark/wireshark/master/tools/debian-setup.sh /
+RUN chmod +x /debian-setup.sh
+
+RUN apt-get update \
+    && /debian-setup.sh --install-optional --install-deb-deps --install-test-deps \
+        g++-4.9 g++-5 g++-6 g++-7 g++-8 \
+        clang-5.0 clang-6.0 clang-7 \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Do not use RUN commands for every small step, it will result in
  unnecessary middle layers.
- Avoid installing gnupg and apt-utils, apt-key is part of the apt
  package so no additional packages should be necessary (I hope!).
- Use the bionic repos since this image is based on 18.04.
- Remove wget and use the ADD command to download a file.
- Use the full key ID (taken from the PPA site and apt.llvm.org)
- Remove gcc, etc. since these are dependencies for g++, etc.
- Remove the contents of /var/lib/apt/lists/ to reduce the image size.
___
Note: untested.

`apt-get clean` is not needed since downloaded deb files are not kept. Instead I removed /var/lib/apt/lists/ as suggested here: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run